### PR TITLE
chore: Add SPDX license identifiers and update setup-uv to v8.2.0

### DIFF
--- a/.github/actions/python_setup/action.yaml
+++ b/.github/actions/python_setup/action.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: 'python_setup'
 description: 'Setup for Python and uv'
 
@@ -5,21 +7,17 @@ inputs:
   python-version:
     description: 'Python version, supporting MAJOR.MINOR only'
     required: true
-    type: string
   uv-version:
     description: 'uv version, default latest'
     required: false
-    type: string
     default: 'latest'
   enable-cache:
     description: 'Enable caching uv cache, default true'
     required: false
-    type: boolean
-    default: true
+    default: 'true'
   save-cache:
     description: 'Save the uv cache, false if pull_request'
     required: false
-    type: boolean
     default: ${{ github.event_name != 'pull_request' }}
 
 runs:
@@ -33,7 +31,7 @@ runs:
 
     - name: 'Setup uv ${{ inputs.uv-version }}'
       id: setup-uv
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         python-version: ${{ steps.setup-python.outputs.python-version }}
         version: ${{ inputs.uv-version }}

--- a/.github/pinact.yaml
+++ b/.github/pinact.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 version: 3
 min_age: # cooldown
   value: 7

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Lint
 
 on:
@@ -6,8 +8,8 @@ on:
       - main
     paths:
       - '**.md'
-      - '.markdownlint-cli2.yaml'
-      - '.github/workflows/lint.yml' # This workflow
+      - '.markdownlint-cli2.ya?ml'
+      - '.github/workflows/lint.ya?ml' # This workflow
 
 env:
   LC_ALL: en_US.UTF-8

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Spellcheck
 
 on:

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 rules:
   unpinned-uses:
     config:

--- a/.poutine.yml
+++ b/.poutine.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 ignoreForks: true
 
 skip:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 # Run `pre-commit install` to activate pre-commit hooks

--- a/.spellcheck.yaml
+++ b/.spellcheck.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 spellchecker: aspell
 
 matrix:


### PR DESCRIPTION
# Summary

This pull request adds SPDX license identifiers to configuration files, updates the `setup-uv` GitHub Action to v8.2.0, and makes improvements to the Python setup action configuration. Additionally, it renames the lint workflow file from `.yml` to `.yaml` for consistency and updates path patterns to support both extensions.

# Files Changed

📄 `.github/actions/python_setup/action.yaml`

Adds Apache-2.0 SPDX license identifier, removes redundant `type` specifications from input definitions (as they're not needed for composite actions), changes the `enable-cache` default from boolean `true` to string `'true'` for consistency, and updates the `setup-uv` action from v8.1.0 to v8.2.0 with the corresponding commit hash.

📄 `.github/pinact.yaml`

Adds Apache-2.0 SPDX license identifier to the pinact configuration file.

📄 `.github/workflows/lint.yml` → `.github/workflows/lint.yaml`

Renames the file from `.yml` to `.yaml` extension, adds Apache-2.0 SPDX license identifier, and updates path patterns to use glob pattern `.ya?ml` to match both `.yaml` and `.yml` extensions for markdownlint configuration and the workflow file itself.

📄 `.github/workflows/spellcheck.yaml`

Adds Apache-2.0 SPDX license identifier to the spellcheck workflow file.

📄 `.github/zizmor.yaml`

Adds Apache-2.0 SPDX license identifier to the zizmor configuration file.

📄 `.poutine.yml`

Adds Apache-2.0 SPDX license identifier to the poutine configuration file.

📄 `.pre-commit-config.yaml`

Adds Apache-2.0 SPDX license identifier to the pre-commit configuration file.

📄 `.spellcheck.yaml`

Adds Apache-2.0 SPDX license identifier to the spellcheck configuration file.